### PR TITLE
remove index prop from MoveResize tag call

### DIFF
--- a/src/index.svelte
+++ b/src/index.svelte
@@ -9,7 +9,6 @@
     <MoveResize
       on:repaint={handleRepaint}
       id={item.id}
-      index={i}
       resizable={item.resizable}
       draggable={item.draggable}
       {xPerPx}


### PR DESCRIPTION
prop `index` is set, but is not referenced nor exported in MoveResize.
It triggers a warning when compiled with svelte 3