### PR TITLE
`getComputedCols` Reacts to `Cols`

### DIFF
--- a/src/index.svelte
+++ b/src/index.svelte
@@ -73,8 +73,9 @@
   let prevCols;
 
   $: {
+    getComputedCols = getColumn(width, cols);
     if (prevCols !== cols && dynamicCols) {
-      xPerPx = containerWidth / getColumn(containerWidth, cols);
+      xPerPx = containerWidth / getComputedCols;
     }
     prevCols = cols;
   }

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -74,7 +74,7 @@
 
   $: {
     if (prevCols !== cols && dynamicCols) {
-      xPerPx = containerWidth / cols;
+      xPerPx = containerWidth / getColumn(containerWidth, cols);
     }
     prevCols = cols;
   }


### PR DESCRIPTION
I spent quite a bit of time debugging an issue where Grid was not updating with the `cols` property. When the new value has breakpoints, `xPerPx` will be `NaN`. This is not the case with simple values for `cols` and is likely how this bug was never caught before. JS will allow arithmetic with arrays containing only one value. 
![image](https://user-images.githubusercontent.com/3579057/100593844-c45b9780-32ad-11eb-9c0f-e0a50136de71.png)

Example of how this breaks: https://svelte.dev/repl/114f508411f64d539d5a0fe252c6c30f?version=3.30.0