### PR TITLE
Replace lodash throttle dependency with ES build version for Svelteki…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,10 @@
     "": {
       "version": "4.0.2",
       "license": "MIT",
-      "dependencies": {
-        "lodash.throttle": "^4.1.1"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "eslint": "^7.13.0",
+        "lodash-es": "^4.17.21",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.2.0",
         "prettier-plugin-svelte": "^1.4.1",
@@ -159,6 +157,7 @@
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.1.0.tgz",
       "integrity": "sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "commondir": "^1.0.1",
@@ -1250,10 +1249,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1774,10 +1774,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.42.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.1.tgz",
-      "integrity": "sha512-/y7M2ULg06JOXmMpPzhTeQroJSchy8lX8q6qrjqil0jmLz6ejCWbQzVnWTsdmMQRhfU0QcwtiW8iZlmrGXWV4g==",
+      "version": "2.42.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.3.tgz",
+      "integrity": "sha512-JjaT9WaUS5vmjy6xUrnPOskjkQg2cN4WSACNCwbOvBz8VDmbiKVdmTFUoMPRqTud0tsex8Xy9/boLbDW9HKD1w==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.1"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -1836,9 +1839,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3145,10 +3148,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -3536,9 +3540,9 @@
       }
     },
     "rollup": {
-      "version": "2.42.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.1.tgz",
-      "integrity": "sha512-/y7M2ULg06JOXmMpPzhTeQroJSchy8lX8q6qrjqil0jmLz6ejCWbQzVnWTsdmMQRhfU0QcwtiW8iZlmrGXWV4g==",
+      "version": "2.42.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.3.tgz",
+      "integrity": "sha512-JjaT9WaUS5vmjy6xUrnPOskjkQg2cN4WSACNCwbOvBz8VDmbiKVdmTFUoMPRqTud0tsex8Xy9/boLbDW9HKD1w==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
@@ -3586,9 +3590,9 @@
       }
     },
     "semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "eslint": "^7.13.0",
+    "lodash-es": "^4.17.21",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.0",
     "prettier-plugin-svelte": "^1.4.1",
@@ -46,8 +47,5 @@
   "files": [
     "src",
     "build"
-  ],
-  "dependencies": {
-    "lodash.throttle": "^4.1.1"
-  }
+  ]
 }

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -43,7 +43,7 @@
   import { moveItemsAroundItem, moveItem, getItemById } from "./utils/item.js";
   import { onMount, createEventDispatcher } from "svelte";
   import { getColumn } from "./utils/other.js";
-  import throttle from "lodash.throttle";
+  import { throttle } from "lodash";
 
   import MoveResize from "./MoveResize/index.svelte";
 


### PR DESCRIPTION
Adds sveltekit/vitejs/snowpack support with es module version of lodash.

**Potentially breaking change**, @vaheqelyan may want to consider incrementing major release version number. 

Closes #85