### PR TITLE
Simple fix to make items not jump if Grid is resized.

### DIFF
--- a/src/MoveResize/index.svelte
+++ b/src/MoveResize/index.svelte
@@ -63,7 +63,9 @@
   class="svlt-grid-item"
   class:svlt-grid-active={active || (trans && rect)}
   style="width: {active ? newSize.width : width}px; height:{active ? newSize.height : height}px; 
-  {active ? `transform: translate(${cordDiff.x}px, ${cordDiff.y}px);top:${rect.top}px;left:${rect.left}px;` : trans ? `transform: translate(${cordDiff.x}px, ${cordDiff.y}px); position:absolute; transition: width 0.2s, height 0.2s;` : `transition: transform 0.2s, opacity 0.2s; transform: translate(${left}px, ${top}px); `} ">
+  {active ? `transform: translate(${cordDiff.x}px, ${cordDiff.y}px);top:${rect.top}px;left:${rect.left}px;` 
+  : trans ? `transform: translate(${cordDiff.x}px, ${cordDiff.y}px); position:absolute; transition: width 0.2s, height 0.2s;` 
+  : `transition: transform ${moveAnimation ? 0.2 : 0}s, opacity 0.2s; transform: translate(${left}px, ${top}px); `} ">
   <slot movePointerDown={pointerdown} {resizePointerDown} />
   {#if resizable && !item.customResizer}
     <div class="svlt-grid-resizer" on:pointerdown={resizePointerDown} />
@@ -87,6 +89,7 @@
 
   export let resizable;
   export let draggable;
+  export let moveAnimation;
 
   export let id;
   export let container;

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -16,6 +16,7 @@
         draggable={item[getComputedCols] && item[getComputedCols].draggable}
         {xPerPx}
         {yPerPx}
+        {moveAnimation}
         width={Math.min(getComputedCols, item[getComputedCols] && item[getComputedCols].w) * xPerPx - gapX * 2}
         height={(item[getComputedCols] && item[getComputedCols].h) * yPerPx - gapY * 2}
         top={(item[getComputedCols] && item[getComputedCols].y) * yPerPx + gapY}
@@ -57,6 +58,7 @@
   export let fastStart = false;
   export let throttleUpdate = 100;
   export let throttleResize = 100;
+  export let moveAnimation = true;
 
   export let scroller = undefined;
   export let sensor = 20;


### PR DESCRIPTION
Quick and dirty fix for the jumping items on Grid resize problem #125.

If moveAnimation = true nothing changes.
If moveAnimation = false the items will not play a move animation and jump directly to the desired spots.
This fixes the item jumps when the Grid component itself changes size. 

This also affects regular movement of components as they will now also jump to their desired spots instead of transitioning. This could be improved by combining the moveAnimation flag with on:resize listener in a more sophisticated approach.